### PR TITLE
fix: decimal field in correction migration

### DIFF
--- a/src/database/migrations/1624118777327-AlterCorrectionsChangeRating.ts
+++ b/src/database/migrations/1624118777327-AlterCorrectionsChangeRating.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AlterCorrectionsChangeRating1624118777327 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.changeColumn(
+      'correction',
+      'rating',
+      new TableColumn({
+        name: 'rating',
+        type: 'decimal',
+        precision: 4,
+        scale: 2,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.changeColumn(
+      'correction',
+      'rating',
+      new TableColumn({
+        name: 'rating',
+        type: 'decimal',
+        precision: 3,
+        scale: 2,
+      }),
+    );
+  }
+}


### PR DESCRIPTION
In this PR, the decimal field has been changed to an accuracy of 4 and a scale of 2.

**Status:** Done